### PR TITLE
docker/renovate: manage alpine image by version instead of latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,14 @@ jobs:
         run: |
           sudo apt-get -qqy update && sudo apt-get -qqy install rpm
 
+      # setup qemu and buildx for cross-builds (arm64)
+      - name: Set up QEMU (for arm64 builds)
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
+
+      # finally run goreleaser to build and publish all artifacts:
       - name: Deploy Autotag Release
         # TODO(vtopc): switch to the `goreleaser/goreleaser-action` GHA?
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.21.0
 
 RUN apk add --no-cache git
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -42,6 +42,13 @@
       "schedule": [
         "after 10pm on the first day of the month"
       ]
+    },
+    {
+      "description": "Don't pin alpine image SHAs, updates too frequently",
+      "matchPackageNames": [
+        "alpine"
+      ],
+      "pinDigests": false
     }
   ],
   "labels": [


### PR DESCRIPTION
we don't need to follow latest anymore now that we have renovate
managing dependencies. When alpine releases a new tag we should get
automatic PR's

also my previous PR that attempted to add multi-arch docker images failed, so this includes a potential fix for that too