### PR TITLE
[minor] add strict match option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,37 @@ refactor!: drop support for Node 6
 
 If no keywords are specified a **Patch** bump is applied.
 
+### Strict Match Option
+
+The `--strict-match` option enforces that commit messages must strictly adhere to the specified commit message scheme.
+When this option is enabled, the parser will return an error if a commit message does not conform to
+the expected format, preventing the commit from being processed. This ensures that only commits with valid messages
+are considered for version bumps.
+
+#### Effect on Default Behavior for All Schemes
+
+When the `--strict-match` option is enabled, the behavior of the commit message parsing changes as follows:
+
+- **Autotag Scheme**:
+  - Without `--strict-match`: Commit messages that do not contain `[major]`, `[minor]`, or `[patch]` will result in a
+  patch version bump by default.
+  - With `--strict-match`: Commit messages that do not contain `[major]`, `[minor]`, or `[patch]` will result in an
+  error, and the commit will not be processed.
+
+- **Conventional Commits Scheme**:
+  - Without `--strict-match`: Commit messages that do not follow the conventional commit format will result in a
+  patch version bump by default.
+  - With `--strict-match`: Commit messages that do not follow the conventional commit format will result in an
+  error, and the commit will not be processed.
+
+#### Usage
+
+To use the strict match option, add the `--strict-match` flag when running the autotag tool:
+
+```sh
+autotag --strict-match
+```
+
 ### Pre-Release Tags
 
 `autotag` supports appending additional text to the calculated next version string:

--- a/autotag.go
+++ b/autotag.go
@@ -126,7 +126,9 @@ type GitRepoConfig struct {
 	// Prefix prepends literal 'v' to the tag, eg: v1.0.0. Enabled by default
 	Prefix bool
 
-	// Prefix prepends literal 'v' to the tag, eg: v1.0.0. Enabled by default
+	// StrictMatch enforces strict mode on the scheme parsers, returning an error if no match is found.
+	// This is useful for CI/CD pipelines where you want to ensure that the commit message adheres to the scheme.
+	// Disabled by default.
 	StrictMatch bool
 }
 

--- a/autotag/main.go
+++ b/autotag/main.go
@@ -21,6 +21,7 @@ type Options struct {
 	BuildMetadata       string `short:"m" long:"build-metadata" description:"optional SemVer build metadata to append to the version with '+' character"`
 	Scheme              string `short:"s" long:"scheme" description:"The commit message scheme to use (can be: autotag|conventional)" default:"autotag"`
 	NoVersionPrefix     bool   `short:"e" long:"empty-version-prefix" description:"Do not prepend v to version tag"`
+	StrictMatch         bool   `long:"strict-match" description:"Enforce strict mode on the scheme parsers, returns error if no match is found"`
 }
 
 var opts Options
@@ -47,6 +48,7 @@ func main() {
 		BuildMetadata:             opts.BuildMetadata,
 		Scheme:                    opts.Scheme,
 		Prefix:                    !opts.NoVersionPrefix,
+		StrictMatch:               opts.StrictMatch,
 	})
 	if err != nil {
 		log.SetOutput(os.Stderr)


### PR DESCRIPTION
## Description

This PR introduces a new `--strict-match` option to autotag.
When enabled, this option enforces strict adherence to the specified commit message scheme (either autotag or conventional). If a commit message does not conform to the expected format, the parser will return an error, and the commit will not be processed. This feature ensures that only commits with valid messages are considered for version bumps, improving the reliability and consistency of versioning. 

## Changes
* Added `--strict-match` flag to the CLI options.
* Updated `parseCommit` function to handle strict match enforcement.
* Modified `parseConventionalCommit` and `parseAutotagCommit` functions to return nil if the commit message does not match the expected format when strict match is enabled.
* Added tests to verify the behavior of the strict match option.