### PR TITLE
[chore] updated goreleaser and golangci configs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,22 @@
-# golangci-lint configuration, shared between `make lint` and `golangci/golangci-lint-action` GitHub Action
-# https://github.com/golangci/golangci/wiki/Configuration
-
+version: "2"
 linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
     - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,22 +87,22 @@ changelog:
 archives:
   # Old release format for backwards compatibility with existing scripts:  Binary named 'Linux'
   - id: old-format-linux
-    builds: ["linux-amd64-only"]
+    ids: ["linux-amd64-only"]
     formats: [binary]
     name_template: "Linux"
   # Old release format for backwards compatibility with existing scripts:  Binary named 'OSX'
   - id: old-format-osx
-    builds: ["macos-amd64-only"]
+    ids: ["macos-amd64-only"]
     formats: [binary]
     name_template: "OSX"
   # New release format, binaries for all platforms in the form: `autotag_linux_amd64`
   - id: new-format-binary-only-all-platforms
     formats: [binary]
-    builds: ["linux", "macos"]
+    ids: ["linux", "macos"]
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
   # archive releases containing: binary, readme, and license. tarballs (macos, linux), zip (windows)
   - id: archives
-    builds: ["linux", "macos"]
+    ids: ["linux", "macos"]
     name_template: '{{ .ProjectName }}_{{ .Os }}_{{ if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}'
     format_overrides:
       - goos: windows


### PR DESCRIPTION
# Config Updates
* goreleaser configuration update: builds field replaced with ids [archives.builds](https://goreleaser.com/deprecations/#archivesbuilds)
* golangci configuration update: Update to version to (`golangci-lint migrate`)